### PR TITLE
Cupcakes loadouts setup

### DIFF
--- a/Templates/#2MRB_Altis_Quick_Training.Altis/initPlayerLocal.sqf
+++ b/Templates/#2MRB_Altis_Quick_Training.Altis/initPlayerLocal.sqf
@@ -12,17 +12,10 @@ CUP_homeBaseSpawn = [player, home_base_spawn_location, "Home Base"] call BIS_fnc
 
 {true} call compile preprocessfilelinenumbers "scripts\boardInit.sqf";
 
+[] call loadoutBoxesSetup;
+
 {true} call compile preprocessfilelinenumbers "cupspec\cupspec_init.sqf";
 
 [spectatorcam, 5] call CUPSPEC_addSpectateObject;
 
 player createDiaryRecord ["Diary", ["Training", "Use the Map object to select training type <br />1. Outdoor CQC  <br />2. Indoor CQC<br />3. Movement Practice<br /><br />Features(I guess)<br />- Auto-create Spawn Points for different groups and assign players to specific groups depending on which point you spawn to.<br />- Use the Signboard to teleport to the respective spawn sites.<br />- Pressing the option on the map object would result in resetting the whole signboard of spawn points.<br />- Right now, for winning sides, please use RTB on action menu to return to base.<br />- Unit dying would result in respawning back in base, while showing remaining count on every side.<br />RTB or Dying would return player to 'waiting' group.<br />- Movement Practice is inspired by our recent failures on checking our 6. It works by making random starting points for different teams and each team is to travel to the opposite side of the square, indicated on the map, from their starting point. Due to how opponents might end up coming from behind or even right in front of you, I believe this can be used to train our ability to react and also take note of our surroundings better.<br /><br />Note: As of now, attires have to be set on your own using Arsenal. This is supposed to just simplify spawning and randomizing spawn points for slightly better variation. To reinforce IDing targets, IND has been introduced into the spawn as well for 3 sided fights, where allies and enemies are to be decided before starting."]];
-
-/*
-Notes - I'll be using these later
-
-BLUFOR: #004c99
-OPFOR: #800000
-INDFOR: #008000
-CIVILIAN: #660080
-*/

--- a/Templates/#2MRB_Altis_Quick_Training.Altis/initServer.sqf
+++ b/Templates/#2MRB_Altis_Quick_Training.Altis/initServer.sqf
@@ -2,17 +2,6 @@ veh = createVehicle ["C_Heli_Light_01_civil_F",position cupcakes_secret_littlebi
 [veh,["wasp",1],["AddCargoHook_COver",0]] call BIS_fnc_initVehicle;
 veh lock 2;
 
-original = createGroup WEST;
-groupB = createGroup WEST;
-groupO = createGroup EAST;
-groupI = createGroup INDEPENDENT;
-
-publicVariable "groupB";
-publicVariable "groupO";
-publicVariable "groupI";
-
-publicVariable "original";
-
 /*veh addEventHandler ["Hit", {
   _veh = _this select 0;
   _culprit = _this select 1;

--- a/Templates/#2MRB_Altis_Quick_Training.Altis/loadouts/blufor/rifleman.sqf
+++ b/Templates/#2MRB_Altis_Quick_Training.Altis/loadouts/blufor/rifleman.sqf
@@ -1,0 +1,30 @@
+this = _this select 1;
+
+comment "Remove existing items";
+removeAllWeapons this;
+removeAllItems this;
+removeAllAssignedItems this;
+removeUniform this;
+removeVest this;
+removeBackpack this;
+removeHeadgear this;
+
+comment "Add containers";
+this forceAddUniform "rhs_uniform_FROG01_wd";
+for "_i" from 1 to 4 do {this addItemToUniform "rhs_mag_30Rnd_556x45_Mk318_Stanag";};
+this addVest "V_HarnessO_brn";
+this addItemToVest "ACE_EarPlugs";
+for "_i" from 1 to 10 do {this addItemToVest "ACE_fieldDressing";};
+for "_i" from 1 to 3 do {this addItemToVest "ACE_morphine";};
+for "_i" from 1 to 2 do {this addItemToVest "HandGrenade";};
+for "_i" from 1 to 4 do {this addItemToVest "SmokeShell";};
+for "_i" from 1 to 4 do {this addItemToVest "rhs_mag_30Rnd_556x45_Mk318_Stanag";};
+
+comment "Add weapons";
+this addWeapon "rhs_weap_m16a4_carryhandle";
+
+comment "Add items";
+this linkItem "ItemMap";
+this linkItem "ItemCompass";
+this linkItem "ItemWatch";
+this linkItem "ItemGPS";

--- a/Templates/#2MRB_Altis_Quick_Training.Altis/loadouts/indfor/rifleman.sqf
+++ b/Templates/#2MRB_Altis_Quick_Training.Altis/loadouts/indfor/rifleman.sqf
@@ -1,0 +1,30 @@
+comment "Exported from Arsenal by SSgt Cupcake";
+
+comment "Remove existing items";
+removeAllWeapons this;
+removeAllItems this;
+removeAllAssignedItems this;
+removeUniform this;
+removeVest this;
+removeBackpack this;
+removeHeadgear this;
+
+comment "Add containers";
+this forceAddUniform "rhsgref_uniform_reed";
+for "_i" from 1 to 4 do {this addItemToUniform "rhs_30Rnd_545x39_AK";};
+this addVest "V_HarnessO_gry";
+for "_i" from 1 to 10 do {this addItemToVest "ACE_fieldDressing";};
+for "_i" from 1 to 3 do {this addItemToVest "ACE_morphine";};
+this addItemToVest "ACE_EarPlugs";
+for "_i" from 1 to 4 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+for "_i" from 1 to 2 do {this addItemToVest "HandGrenade";};
+for "_i" from 1 to 4 do {this addItemToVest "SmokeShell";};
+
+comment "Add weapons";
+this addWeapon "rhs_weap_ak74";
+
+comment "Add items";
+this linkItem "ItemMap";
+this linkItem "ItemCompass";
+this linkItem "ItemWatch";
+this linkItem "ItemGPS";

--- a/Templates/#2MRB_Altis_Quick_Training.Altis/loadouts/opfor/rifleman.sqf
+++ b/Templates/#2MRB_Altis_Quick_Training.Altis/loadouts/opfor/rifleman.sqf
@@ -1,0 +1,30 @@
+comment "Exported from Arsenal by SSgt Cupcake";
+
+comment "Remove existing items";
+removeAllWeapons this;
+removeAllItems this;
+removeAllAssignedItems this;
+removeUniform this;
+removeVest this;
+removeBackpack this;
+removeHeadgear this;
+
+comment "Add containers";
+this forceAddUniform "rhs_uniform_emr_patchless";
+for "_i" from 1 to 4 do {this addItemToUniform "rhs_30Rnd_545x39_AK";};
+this addVest "V_HarnessO_ghex_F";
+this addItemToVest "ACE_EarPlugs";
+for "_i" from 1 to 10 do {this addItemToVest "ACE_fieldDressing";};
+for "_i" from 1 to 3 do {this addItemToVest "ACE_morphine";};
+for "_i" from 1 to 4 do {this addItemToVest "rhs_30Rnd_545x39_AK";};
+for "_i" from 1 to 4 do {this addItemToVest "SmokeShell";};
+for "_i" from 1 to 2 do {this addItemToVest "HandGrenade";};
+
+comment "Add weapons";
+this addWeapon "rhs_weap_ak105_zenitco01_b33";
+
+comment "Add items";
+this linkItem "ItemMap";
+this linkItem "ItemCompass";
+this linkItem "ItemWatch";
+this linkItem "ItemGPS";

--- a/Templates/#2MRB_Altis_Quick_Training.Altis/mission.sqm
+++ b/Templates/#2MRB_Altis_Quick_Training.Altis/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=9;
 	class ItemIDProvider
 	{
-		nextID=1050;
+		nextID=1053;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={9171.1377,20.424181,21650.35};
-		dir[]={-0.66778922,-0.74432057,0.0070093675};
-		up[]={-0.74427909,0.66782099,0.0078123095};
-		aside[]={0.01049622,5.0087692e-008,0.99994481};
+		pos[]={9167.0205,22.346331,21643.781};
+		dir[]={0.085325979,-0.60334027,0.79290783};
+		up[]={0.064553604,0.79748338,0.59987843};
+		aside[]={0.99426115,4.0250598e-008,-0.10699376};
 	};
 };
 binarizationWanted=0;
@@ -48,13 +48,15 @@ addons[]=
 	"CUP_CAMP_Armory_Misc_Info_Board",
 	"A3_Ui_F",
 	"CUP_CWA_Misc",
-	"A3_Characters_F"
+	"A3_Characters_F",
+	"A3_Supplies_F_Exp_Ammoboxes",
+	"ace_dragging"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=23;
+		items=25;
 		class Item0
 		{
 			className="A3_Structures_F";
@@ -207,6 +209,20 @@ class AddonsMetaData
 			name="Arma 3 Alpha - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="http://www.arma3.com";
+		};
+		class Item23
+		{
+			className="A3_Supplies_F_Exp";
+			name="Arma 3 Apex - Ammoboxes and Supplies";
+			author="Bohemia Interactive";
+			url="http://www.arma3.com";
+		};
+		class Item24
+		{
+			className="ace_dragging";
+			name="ACE3 - Dragging";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
 		};
 	};
 };
@@ -371,7 +387,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=104;
+		items=107;
 		class Item0
 		{
 			dataType="Object";
@@ -3815,6 +3831,183 @@ class Mission
 			id=166;
 			type="Logic";
 			atlOffset=-0.00012302399;
+		};
+		class Item104
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9161.8662,14.783031,21654.506};
+				angles[]={0.0013439035,4.2182865,6.2818413};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				name="BLUbox";
+			};
+			id=1050;
+			type="Box_NATO_Equip_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="ammoBox";
+					expression="[_this,_value] call bis_fnc_initAmmoBox;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="ace_isMedicalFacility";
+					expression="_this setVariable [""ace_medical_isMedicalFacility"",_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=2;
+			};
+		};
+		class Item105
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9163.8027,14.781528,21655.563};
+				angles[]={0,4.2225275,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				name="OPbox";
+			};
+			id=1051;
+			type="Box_CSAT_Equip_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="ammoBox";
+					expression="[_this,_value] call bis_fnc_initAmmoBox;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="ace_isMedicalFacility";
+					expression="_this setVariable [""ace_medical_isMedicalFacility"",_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=2;
+			};
+		};
+		class Item106
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9165.7266,14.782499,21656.539};
+				angles[]={0,4.2406611,0.0012915437};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				name="INDbox";
+			};
+			id=1052;
+			type="Box_AAF_Equip_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="ammoBox";
+					expression="[_this,_value] call bis_fnc_initAmmoBox;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="ace_isMedicalFacility";
+					expression="_this setVariable [""ace_medical_isMedicalFacility"",_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=2;
+			};
 		};
 	};
 };

--- a/Templates/#2MRB_Altis_Quick_Training.Altis/scripts/functions.sqf
+++ b/Templates/#2MRB_Altis_Quick_Training.Altis/scripts/functions.sqf
@@ -27,7 +27,7 @@ cqcOut = {
 
 		_spawnPoint deleteAt _index;
 
-		_iPosition = _spawnPoint select 0;
+		_iPosition = selectRandom _spawnPoint;
 
 		bSpawn = getMarkerPos (_selectArea + "_" + str _bPosition);
 		oSpawn = getMarkerPos (_selectArea + "_" + str _oPosition);
@@ -111,7 +111,7 @@ movement = {
 
 		_spawnPoint deleteAt _index;
 
-		_iPosition = _spawnPoint select 0;
+		_iPosition = selectRandom _spawnPoint;
 
 		bSpawn = getMarkerPos (_selectArea + "_" + str _bPosition);
 		oSpawn = getMarkerPos (_selectArea + "_" + str _oPosition);

--- a/Templates/#2MRB_Altis_Quick_Training.Altis/scripts/functions.sqf
+++ b/Templates/#2MRB_Altis_Quick_Training.Altis/scripts/functions.sqf
@@ -151,7 +151,7 @@ returnScript = {
 
 	{
 		_returnee removeAction _x;
-	}forEach playerActions;
+	} forEach playerActions;
 	
 	playerActions = [];
 
@@ -162,57 +162,12 @@ returnScript = {
 	_sideSwitchGroup = createGroup civilian;
 	[player] joinSilent _sideSwitchGroup;
 	
-	call returnOutfit;
-	
 	format ["Active:-\n\nBLUFOR: %1\nOPFOR: %2\nINDFOR: %1", {side _x == west} count allPlayers, {side _x == east} count allPlayers, {side _x == independent} count allPlayers] call print_text;
 };
 
-setOutfitB = {
-	type = _this;
-	
-	switch (type) do {
-		case 1: {
-			call compile preprocessfilelinenumbers "scripts\loadout\Blufor_MARPATWD.sqf";
-		};
-		case 2: {
-			call compile preprocessfilelinenumbers "scripts\loadout\Blufor_OCP.sqf";
-		};
-		case 3: {
-			call compile preprocessfilelinenumbers "scripts\loadout\Blufor_MARPATD.sqf";
-		};
-	};
-};
-
-setOutfitO = {
-	type = _this;
-	
-	switch (type) do {
-		case 1: {
-			call compile preprocessfilelinenumbers "scripts\loadout\Opfor_TTsKOForest.sqf";
-		};
-		case 2: {
-			call compile preprocessfilelinenumbers "scripts\loadout\Opfor_VDVFlora.sqf";
-		};
-		case 3: {
-			call compile preprocessfilelinenumbers "scripts\loadout\Opfor_TTsKOMountain.sqf";
-		};
-	};
-};
-
-setOutfitI = {
-	type = _this;
-	
-	switch (type) do {
-		case 1: {
-			call compile preprocessfilelinenumbers "scripts\loadout\Indfor_SpecterSFlora.sqf";
-		};
-		case 2: {
-			call compile preprocessfilelinenumbers "scripts\loadout\Indfor_MSVEMR.sqf";
-		};
-
-	};
-};
-
-returnOutfit = {
-	call compile preprocessfilelinenumbers "scripts\loadout\2mrb_default.sqf";
+loadoutBoxesSetup = 
+{
+	BLUbox addAction ["<t color='#0080ff'>Rifleman</t>", "loadouts\blufor\rifleman.sqf"];
+	OPbox addAction ["<t color='#ff0000'>Rifleman</t>", "loadouts\opfor\rifleman.sqf"];
+	INDbox addAction ["<t color='#00ff00'>Rifleman</t>", "loadouts\indfor\rifleman.sqf"];
 };


### PR DESCRIPTION
This is my proposal for how the loadouts should work. 

 - Spawn has 3 boxes, one for each side. They are the vanilla side equipment boxes - very distinctive. 
 - Each box has a selection of classes available (rifleman, autorifle, different rifleman, etc.).
 - Selecting the class from a particular box gives you that faction's loadout of that class. 
 - Currently, there is only one loadout for each: a basic rifleman. These are mostly subject to change. However, note the following:
 	- Standard equipment across the board: 8 mags, 2 frags, 4 smokes, 10 bandages, 3 morphines and some earplugs
 	- Uniforms are all very distinctive. They were carefully picked to maximise contrast between factions. 
 	- Nobody has armour - they all use harnesses. 
 	- Nobody has headgear. 
 	- Facewear (goggles, etc.) is left unaffected, to leave a bit of individuality/customisability. 

This also includes a couple of commits that were supposed to go straight to master. Whoops. 